### PR TITLE
fix вылета 1.21.1

### DIFF
--- a/src/main/java/ru/dimaskama/schematicpreview/render/CustomVertexConsumerProvider.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/render/CustomVertexConsumerProvider.java
@@ -5,33 +5,90 @@ import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.BufferAllocator;
 
-public class CustomVertexConsumerProvider extends VertexConsumerProvider.Immediate {
+import java.util.HashMap;
+import java.util.Map;
 
+public class CustomVertexConsumerProvider implements VertexConsumerProvider {
+    private final VertexConsumerProvider.Immediate delegate;
     private final Framebuffer framebuffer;
+    private final Map<RenderLayer, BufferBuilder> layerBuffers;
+    private final BufferAllocator allocator;
 
-    protected CustomVertexConsumerProvider(VertexConsumerProvider.Immediate delegate, Framebuffer framebuffer) {
-        super(delegate.allocator, delegate.layerBuffers);
+    public CustomVertexConsumerProvider(VertexConsumerProvider.Immediate delegate, Framebuffer framebuffer) {
+        this.delegate = delegate;
         this.framebuffer = framebuffer;
+        this.layerBuffers = new HashMap<>();
+        this.allocator = new BufferAllocator(262144);
     }
 
     @Override
-    protected void draw(RenderLayer layer, BufferBuilder builder) {
-        BuiltBuffer builtBuffer = builder.endNullable();
-        if (builtBuffer != null) {
-            if (layer.isTranslucent()) {
-                BufferAllocator bufferAllocator = layerBuffers.getOrDefault(layer, this.allocator);
-                builtBuffer.sortQuads(bufferAllocator, RenderSystem.getVertexSorting());
-            }
-
-            layer.startDrawing();
-            framebuffer.beginWrite(true);
-            BufferRenderer.drawWithGlobalProgram(builtBuffer);
-            layer.endDrawing();
-        }
-
-        if (layer.equals(currentLayer)) {
-            currentLayer = null;
-        }
+    public VertexConsumer getBuffer(RenderLayer layer) {
+        BufferBuilder builder = layerBuffers.computeIfAbsent(layer, k -> 
+            new BufferBuilder(allocator, layer.getDrawMode(), layer.getVertexFormat()));
+        return new CustomVertexConsumer(builder);
     }
 
+    public void draw() {
+        for (Map.Entry<RenderLayer, BufferBuilder> entry : layerBuffers.entrySet()) {
+            RenderLayer layer = entry.getKey();
+            BufferBuilder builder = entry.getValue();
+            BuiltBuffer builtBuffer = builder.endNullable();
+            if (builtBuffer != null) {
+                if (layer.isTranslucent()) {
+                    builtBuffer.sortQuads(allocator, RenderSystem.getVertexSorting());
+                }
+                layer.startDrawing();
+                framebuffer.beginWrite(true);
+                BufferRenderer.drawWithGlobalProgram(builtBuffer);
+                layer.endDrawing();
+                builtBuffer.close();
+            }
+        }
+        layerBuffers.clear();
+        delegate.draw();
+    }
+
+    private class CustomVertexConsumer implements VertexConsumer {
+        private final BufferBuilder builder;
+
+        public CustomVertexConsumer(BufferBuilder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public VertexConsumer vertex(float x, float y, float z) {
+            builder.vertex(x, y, z);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer color(int red, int green, int blue, int alpha) {
+            builder.color(red, green, blue, alpha);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer texture(float u, float v) {
+            builder.texture(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer overlay(int u, int v) {
+            builder.overlay(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer light(int u, int v) {
+            builder.light(u, v);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer normal(float x, float y, float z) {
+            builder.normal(x, y, z);
+            return this;
+        }
+    }
 }


### PR DESCRIPTION
**Добавлен собственный BufferAllocator:**
```
- allocator в конструкторе с размером 262144 байт, что достаточно для большинства задач рендеринга схем.
+ это устраняет зависимость от delegate.allocator и любых потенциальных внутренних проверок доступа.
```

**Использование allocator в sortQuads:**
`- Для прозрачных слоёв теперь используется собственный allocator вместо null, что должно улучшить совместимость.
`
**Сохранён вызов delegate.draw():**
` - Гарантирует, что любые дополнительные слои, обработанные через delegate, будут отрисованы корректно.`