### PR TITLE
Port to Minecraft 26.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id "me.modmuss50.mod-publish-plugin" version "1.1.0"
 }
 
@@ -10,20 +10,14 @@ base {
     archivesName = project.archives_base_name
 }
 
-
 repositories {
-    // Add repositories to retrieve artifacts from in here.
-    // You should only use this when depending on other mods because
-    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-    // for more information about repositories.
     maven {
         url 'https://maven.terraformersmc.com/releases/'
     }
     maven {
         url 'https://masa.dy.fi/maven'
     }
-    maven{
+    maven {
         url "https://jitpack.io"
     }
     exclusiveContent {
@@ -40,20 +34,12 @@ repositories {
 }
 
 dependencies {
-    // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-    // Malilib and Litematica
-    modImplementation "maven.modrinth:malilib:${project.malilib_version}"
-    modImplementation "maven.modrinth:litematica:${project.litematica_version}"
-
-    // modmenu
-    modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "maven.modrinth:malilib:${project.malilib_version}"
+    implementation "maven.modrinth:litematica:${project.litematica_version}"
+    implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 
 loom {
@@ -75,27 +61,15 @@ processResources {
     }
 }
 
-def targetJavaVersion = 21
 tasks.withType(JavaCompile).configureEach {
-    // ensure that the encoding is set to UTF-8, no matter what the system default is
-    // this fixes some edge cases with special characters not displaying correctly
-    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-    // If Javadoc is generated, this must be specified in that task too.
     it.options.encoding = "UTF-8"
-    if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
-        it.options.release.set(targetJavaVersion)
-    }
+    it.options.release = 25
 }
 
 java {
-    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
-    if (JavaVersion.current() < javaVersion) {
-        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
-    }
-    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-    // if it is present.
-    // If you remove this line, sources will not be generated.
     withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -105,7 +79,7 @@ jar {
 }
 
 publishMods {
-    file = remapJar.archiveFile
+    file = jar.archiveFile
     changelog = file('changelog.md').text
     type = STABLE
     modLoaders.add("fabric")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,17 +7,17 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.11
-loader_version=0.18.2
-loom_version=1.14-SNAPSHOT
+minecraft_version=26.1.2
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
 
 # Mod Properties
-mod_version=0.0.16+1.21.11
+mod_version=0.0.20+26.1.2
 maven_group=ru.dimaskama
 archives_base_name=schematicpreview
 
 # Dependencies
-fabric_version=0.139.4+1.21.11
-malilib_version=0.27.2
-litematica_version=0.25.3
-modmenu_version=17.0.0-alpha.1
+fabric_version=0.150.0+26.1.2
+malilib_version=0.28.6
+litematica_version=0.27.6
+modmenu_version=18.0.0-beta.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/ru/dimaskama/schematicpreview/gui/GuiBlockSelect.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/gui/GuiBlockSelect.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
@@ -167,7 +167,7 @@ public class GuiBlockSelect extends GuiBase {
     @Override
     protected void drawContents(GuiContext drawContext, int mouseX, int mouseY, float partialTicks) {
         if (getParent() != null) {
-            getParent().render(drawContext, mouseX, mouseY, partialTicks);
+            getParent().extractRenderState(drawContext, mouseX, mouseY, partialTicks);
         }
 
         RenderUtils.drawOutlinedBox(drawContext, x, y, WIDTH, HEIGHT, 0xAA000000, 0xFFFFFFFF);
@@ -203,7 +203,7 @@ public class GuiBlockSelect extends GuiBase {
             }
         }
 
-        searchField.render(drawContext, mouseX, mouseY, partialTicks);
+        searchField.extractWidgetRenderState(drawContext, mouseX, mouseY, partialTicks);
 
         if (hoveredBlockIndex != -1) {
             Block hoveredBlock = blocks.get(hoveredBlockIndex);

--- a/src/main/java/ru/dimaskama/schematicpreview/gui/widget/CustomSchematicBrowser.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/gui/widget/CustomSchematicBrowser.java
@@ -6,7 +6,6 @@ import fi.dy.masa.malilib.gui.interfaces.ISelectionListener;
 import fi.dy.masa.malilib.gui.widgets.WidgetDirectoryEntry;
 import fi.dy.masa.malilib.gui.widgets.WidgetDirectoryNavigation;
 import fi.dy.masa.malilib.render.GuiContext;
-import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;

--- a/src/main/java/ru/dimaskama/schematicpreview/gui/widget/OnOffButton.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/gui/widget/OnOffButton.java
@@ -1,7 +1,8 @@
 package ru.dimaskama.schematicpreview.gui.widget;
 
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
-import net.minecraft.client.gui.GuiGraphics;
+import fi.dy.masa.malilib.render.GuiContext;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
@@ -33,7 +34,7 @@ public class OnOffButton extends AbstractWidget {
     }
 
     @Override
-    protected void renderWidget(GuiGraphics context, int mouseX, int mouseY, float delta) {
+    protected void extractWidgetRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
         context.blitSprite(
                 RenderPipelines.GUI_TEXTURED,
                 on ? (isHovered() ? offSpriteFocused : offSprite) : (isHovered() ? onSpriteFocused : onSprite),

--- a/src/main/java/ru/dimaskama/schematicpreview/gui/widget/SchematicPreviewWidget.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/gui/widget/SchematicPreviewWidget.java
@@ -12,15 +12,15 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import fi.dy.masa.litematica.schematic.LitematicaSchematic;
 import fi.dy.masa.malilib.gui.widgets.WidgetBase;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import fi.dy.masa.malilib.render.GuiContext;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.render.TextureSetup;
-import net.minecraft.client.gui.render.state.BlitRenderState;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.renderer.GlobalSettingsUniform;
-import net.minecraft.client.renderer.PerspectiveProjectionMatrixBuffer;
+import net.minecraft.client.renderer.ProjectionMatrixBuffer;
 import net.minecraft.client.renderer.RenderPipelines;
-import net.minecraft.client.renderer.state.CameraRenderState;
+import net.minecraft.client.renderer.state.gui.BlitRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.chat.Component;
@@ -94,7 +94,7 @@ public class SchematicPreviewWidget extends WidgetBase {
         this.schematicFile = schematicFile;
     }
 
-    public void renderPreviewAndOverlay(GuiGraphics context, int x, int y, int width, int height) {
+    public void renderPreviewAndOverlay(GuiContext context, int x, int y, int width, int height) {
         SchematicPreview.addTickable(tickAction);
         if (x != this.x || y != this.y || width != this.width || height != this.height) {
             setPosition(x, y);
@@ -141,21 +141,30 @@ public class SchematicPreviewWidget extends WidgetBase {
         }
     }
 
-    private void renderPreviewAndOverlay(GuiGraphics context, float tickDelta) {
+    private void renderPreviewAndOverlay(GuiContext context, float tickDelta) {
         if (fullscreen) {
             context.fill(0, 0, context.guiWidth(), context.guiHeight(), 0xFF000000);
         }
         boolean framebufferUpdated = prepareFramebuffer();
-        if (nonStatic || framebufferUpdated || renderer.needsReRender()) {
-            RenderSystem.getDevice().createCommandEncoder().clearColorAndDepthTextures(
-                    framebuffer.getColorTexture(),
-                    0,
-                    framebuffer.getDepthTexture(),
-                    1.0
-            );
+        boolean needsRedraw = framebufferUpdated || renderer.needsReRender();
+        if (needsRedraw) {
+            boolean fullClear = framebufferUpdated || renderer.needsContentClear();
+            if (fullClear) {
+                RenderSystem.getDevice().createCommandEncoder().clearColorAndDepthTextures(
+                        framebuffer.getColorTexture(),
+                        0xFF000000,
+                        framebuffer.getDepthTexture(),
+                        1.0
+                );
+            } else {
+                RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(
+                        framebuffer.getDepthTexture(),
+                        1.0
+                );
+            }
             renderer.render(framebuffer, tickDelta);
         }
-        context.guiRenderState.submitGuiElement(new BlitRenderState(
+        context.addSimpleElementToCurrentLayer(new BlitRenderState(
                 RenderPipelines.GUI_TEXTURED,
                 TextureSetup.singleTexture(framebuffer.getColorTextureView(), RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR)),
                 new Matrix3x2f(context.pose()),
@@ -168,7 +177,7 @@ public class SchematicPreviewWidget extends WidgetBase {
                 1.0F,
                 0.0F,
                 0xFFFFFFFF,
-                context.scissorStack.peek()
+                context.peekLastScissor()
         ));
         renderOverlay(context, tickDelta);
     }
@@ -188,11 +197,11 @@ public class SchematicPreviewWidget extends WidgetBase {
         return false;
     }
 
-    private void renderOverlay(GuiGraphics context, float tickDelta) {
+    private void renderOverlay(GuiContext context, float tickDelta) {
         int mouseX = getMouseX();
         int mouseY = getMouseY();
         for (AbstractWidget button : buttons) {
-            button.render(context, mouseX, mouseY, tickDelta);
+            button.extractRenderState(context, mouseX, mouseY, tickDelta);
         }
     }
 
@@ -348,7 +357,7 @@ public class SchematicPreviewWidget extends WidgetBase {
         private int lastChunksBuilt;
         private boolean schematicNew;
         @Nullable
-        private PerspectiveProjectionMatrixBuffer projectionMatrix;
+        private ProjectionMatrixBuffer projectionMatrix;
         @Nullable
         private GpuBuffer globalUniform;
 
@@ -405,16 +414,20 @@ public class SchematicPreviewWidget extends WidgetBase {
             return renderer.isBuildingTerrain();
         }
 
+        private boolean needsContentClear() {
+            return schematicNew || !pos.equals(lastRenderPos) || !rot.equals(lastRenderRot);
+        }
+
         private boolean needsReRender() {
-            return schematicNew || !pos.equals(lastRenderPos) || !rot.equals(lastRenderRot) || renderer.getBuiltChunksCount() != lastChunksBuilt;
+            return needsContentClear() || renderer.getBuiltChunksCount() != lastChunksBuilt;
         }
 
         private void render(RenderTarget framebuffer, float tickDelta) {
-            schematicNew = false;
-
             if (isBuildingTerrainOrStart()) {
                 return;
             }
+
+            schematicNew = false;
 
             lastChunksBuilt = renderer.getBuiltChunksCount();
             lastRenderRot.set(Mth.lerp(tickDelta, prevRot.x, rot.x), Mth.rotLerp(tickDelta, prevRot.y, rot.y));
@@ -433,7 +446,7 @@ public class SchematicPreviewWidget extends WidgetBase {
             ).conjugate()));
             RenderSystem.backupProjectionMatrix();
             if (projectionMatrix == null) {
-                projectionMatrix = new PerspectiveProjectionMatrixBuffer("SchematicPreview");
+                projectionMatrix = new ProjectionMatrixBuffer("SchematicPreview");
             }
             RenderSystem.setProjectionMatrix(projectionMatrix.getBuffer(new Matrix4f().perspective(
                     (float) SchematicPreviewConfigs.PREVIEW_FOV.getDoubleValue() * Mth.DEG_TO_RAD,
@@ -466,7 +479,6 @@ public class SchematicPreviewWidget extends WidgetBase {
             cameraRenderState.initialized = true;
             cameraRenderState.orientation = rotation;
             cameraRenderState.pos = new Vec3(lastRenderPos.x, lastRenderPos.y, lastRenderPos.z);
-            cameraRenderState.entityPos = cameraRenderState.pos;
             cameraRenderState.blockPos = BlockPos.containing(cameraRenderState.pos);
             mc.gameRenderer.getLighting().setupFor(Lighting.Entry.LEVEL);
             renderer.prepareRender(cameraRenderState, framebuffer);

--- a/src/main/java/ru/dimaskama/schematicpreview/render/SchematicPreviewRenderer.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/render/SchematicPreviewRenderer.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
@@ -13,21 +14,27 @@ import com.mojang.blaze3d.vertex.MeshData;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexSorting;
-import fi.dy.masa.litematica.render.schematic.IBufferBuilderPatch;
+import fi.dy.masa.litematica.render.schematic.BlockModelRendererSchematic;
+import fi.dy.masa.litematica.render.schematic.IBlockOutputSchematic;
 import fi.dy.masa.litematica.schematic.LitematicaSchematic;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.DynamicUniforms;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.block.FluidRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
-import net.minecraft.client.renderer.chunk.*;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
+import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
-import net.minecraft.client.renderer.state.CameraRenderState;
+import net.minecraft.client.renderer.state.GameRenderState;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
@@ -37,6 +44,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.SingleThreadedRandomSource;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
@@ -44,11 +52,14 @@ import ru.dimaskama.schematicpreview.SchematicPreview;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 
 public class SchematicPreviewRenderer implements AutoCloseable {
 
     private final WorldSchematicWrapper world;
-    private final BlockRenderDispatcher blockRenderManager;
+    private final FluidRenderer fluidRenderer;
+    private final ModelManager modelManager;
     private final BlockEntityRenderDispatcher blockEntityRenderManager;
     private final SubmitNodeStorage orderedRenderCommandQueue;
     private final CustomVertexConsumerProvider customVertexConsumerProvider;
@@ -63,18 +74,20 @@ public class SchematicPreviewRenderer implements AutoCloseable {
 
     public SchematicPreviewRenderer(Minecraft mc) {
         world = new WorldSchematicWrapper(mc);
-        blockRenderManager = mc.getBlockRenderer();
+        modelManager = mc.getModelManager();
+        fluidRenderer = new FluidRenderer(modelManager.getFluidStateModelSet());
         blockEntityRenderManager = mc.getBlockEntityRenderDispatcher();
         orderedRenderCommandQueue = new SubmitNodeStorage();
         customVertexConsumerProvider = new CustomVertexConsumerProvider(mc.renderBuffers().bufferSource());
         renderDispatcher = new FeatureRenderDispatcher(
                 orderedRenderCommandQueue,
-                blockRenderManager,
+                modelManager,
                 customVertexConsumerProvider,
                 mc.getAtlasManager(),
                 new DummyOutlineVertexConsumerProvider(),
                 new DummyVertexConsumerProvider(),
-                mc.font
+                mc.font,
+                new GameRenderState()
         );
     }
 
@@ -92,12 +105,20 @@ public class SchematicPreviewRenderer implements AutoCloseable {
                 chunks.add(new ChunkEntry(chunkPos, CompletableFuture.supplyAsync(() -> {
                     RandomSource random = new SingleThreadedRandomSource(0);
                     BuiltChunk chunk = new BuiltChunk();
-                    PoseStack matrices = new PoseStack();
+                    BlockModelRendererSchematic blockModelRenderer = new BlockModelRendererSchematic();
+                    blockModelRenderer.enableCache();
                     BlockPos.MutableBlockPos worldPos = new BlockPos.MutableBlockPos();
                     int chunkStartX = chunkPos.getMinBlockX();
                     int chunkStartZ = chunkPos.getMinBlockZ();
                     int chunkEndX = chunkStartX + 16;
                     int chunkEndZ = chunkStartZ + 16;
+
+                    IBlockOutputSchematic blockOutput = (bx, by, bz, quad, inst) -> {
+                        ChunkSectionLayer layer = quad.materialInfo().layer();
+                        BufferBuilder builder = chunk.getBuilderByLayer(layer);
+                        builder.putBlockBakedQuad(bx, by, bz, quad, inst);
+                    };
+
                     for (int y = 0; y < height; y++) {
                         for (int z = chunkStartZ; z < chunkEndZ; z++) {
                             for (int x = chunkStartX; x < chunkEndX; x++) {
@@ -110,35 +131,28 @@ public class SchematicPreviewRenderer implements AutoCloseable {
                                 FluidState fluid = state.getFluidState();
                                 boolean renderFluid = !fluid.isEmpty();
                                 boolean renderBlock = state.getRenderShape() == RenderShape.MODEL;
-                                if (renderFluid || renderBlock) {
-                                    matrices.pushPose();
-                                    matrices.translate(worldPos.getX() & 0xF, worldPos.getY(), worldPos.getZ() & 0xF);
-                                    if (renderFluid) {
-                                        ChunkSectionLayer layer = ItemBlockRenderTypes.getRenderLayer(fluid);
-                                        BufferBuilder builder = chunk.getBuilderByLayer(layer);
-                                        ((IBufferBuilderPatch) builder).litematica$setOffsetY((worldPos.getY() >> 4) << 4);
-                                        blockRenderManager.renderLiquid(worldPos, world, builder, state, fluid);
-                                        ((IBufferBuilderPatch) builder).litematica$setOffsetY(0.0F);
-                                    }
-                                    if (renderBlock) {
-                                        ChunkSectionLayer layer = ItemBlockRenderTypes.getChunkRenderType(state);
-                                        BufferBuilder builder = chunk.getBuilderByLayer(layer);
-                                        blockRenderManager.getModelRenderer().tesselateWithAO(
-                                                world,
-                                                blockRenderManager.getBlockModel(state).collectParts(random),
-                                                state,
-                                                worldPos,
-                                                matrices,
-                                                builder,
-                                                true,
-                                                OverlayTexture.NO_OVERLAY
-                                        );
-                                    }
-                                    matrices.popPose();
+                                Vec3 offset = new Vec3(x & 0xF, y, z & 0xF);
+
+                                if (renderFluid) {
+                                    FluidRenderer.Output fluidOutput = chunk::getBuilderByLayer;
+                                    fluidRenderer.tesselate(world, worldPos, fluidOutput, state, fluid);
+                                }
+                                if (renderBlock) {
+                                    BlockStateModel model = modelManager.getBlockStateModelSet().get(state);
+                                    blockModelRenderer.tessellateBlock(
+                                            world,
+                                            state,
+                                            worldPos,
+                                            offset,
+                                            model,
+                                            state.getSeed(worldPos),
+                                            blockOutput
+                                    );
                                 }
                             }
                         }
                     }
+                    blockModelRenderer.disableCache();
                     return chunk;
                 })));
             }
@@ -151,28 +165,27 @@ public class SchematicPreviewRenderer implements AutoCloseable {
         updated = !pos.equals((float) cameraRenderState.pos.x, (float) cameraRenderState.pos.y, (float) cameraRenderState.pos.z);
         if (updated) {
             pos.set(cameraRenderState.pos.x, cameraRenderState.pos.y, cameraRenderState.pos.z);
-            ChunkPos chunkPos = new ChunkPos(Mth.floor(cameraRenderState.pos.x) >> 4, Mth.floor(cameraRenderState.pos.z) >> 4);
-            if (!this.chunkPos.equals(chunkPos)) {
-                this.chunkPos = chunkPos;
-                chunks.sort(Comparator.comparingInt(chunk -> -(Math.abs(chunk.pos.x - chunkPos.x) + Math.abs(chunk.pos.z - chunkPos.z))));
+            ChunkPos newChunkPos = new ChunkPos(Mth.floor(cameraRenderState.pos.x) >> 4, Mth.floor(cameraRenderState.pos.z) >> 4);
+            if (!this.chunkPos.equals(newChunkPos)) {
+                this.chunkPos = newChunkPos;
+                chunks.sort(Comparator.comparingInt(chunk -> -(Math.abs(chunk.pos().x() - newChunkPos.x()) + Math.abs(chunk.pos().z() - newChunkPos.z()))));
             }
         }
     }
 
-    @SuppressWarnings("deprecation")
     private ChunkSectionsToRender prepareChunks() {
         Iterator<ChunkEntry> chunkIterator = chunks.iterator();
-        EnumMap<ChunkSectionLayer, List<RenderPass.Draw<GpuBufferSlice[]>>> enumMap = new EnumMap<>(ChunkSectionLayer.class);
-        int i = 0;
+        EnumMap<ChunkSectionLayer, Int2ObjectOpenHashMap<List<com.mojang.blaze3d.systems.RenderPass.Draw<GpuBufferSlice[]>>>> enumMap = new EnumMap<>(ChunkSectionLayer.class);
+        int maxIndices = 0;
 
-        for(ChunkSectionLayer chunkSectionLayer : ChunkSectionLayer.values()) {
-            enumMap.put(chunkSectionLayer, new ArrayList<>());
+        for (ChunkSectionLayer chunkSectionLayer : ChunkSectionLayer.values()) {
+            enumMap.put(chunkSectionLayer, new Int2ObjectOpenHashMap<>());
         }
 
-        List<DynamicUniforms.ChunkSectionInfo> list = new ArrayList<>();
-        GpuTextureView gpuTextureView = Minecraft.getInstance().getTextureManager().getTexture(TextureAtlas.LOCATION_BLOCKS).getTextureView();
-        int j = gpuTextureView.getWidth(0);
-        int k = gpuTextureView.getHeight(0);
+        List<DynamicUniforms.ChunkSectionInfo> chunkSectionInfos = new ArrayList<>();
+        GpuTextureView blockAtlas = Minecraft.getInstance().getTextureManager().getTexture(TextureAtlas.LOCATION_BLOCKS).getTextureView();
+        int atlasWidth = blockAtlas.getWidth(0);
+        int atlasHeight = blockAtlas.getHeight(0);
 
         while (chunkIterator.hasNext()) {
             ChunkEntry chunk = chunkIterator.next();
@@ -184,76 +197,111 @@ public class SchematicPreviewRenderer implements AutoCloseable {
                 continue;
             }
             VertexSorting vertexSorter = VertexSorting.byDistance(pos.x - chunk.pos().getMinBlockX(), pos.y, pos.z - chunk.pos().getMinBlockZ());
+            int uniformIndex = -1;
 
-            int m = -1;
-
-            for (ChunkSectionLayer chunkSectionLayer2 : ChunkSectionLayer.values()) {
-                built.uploadBuffer(chunkSectionLayer2, vertexSorter);
+            for (ChunkSectionLayer layer : ChunkSectionLayer.values()) {
+                built.uploadBuffer(layer, vertexSorter);
                 if (updated) {
-                    built.resortTransparent(chunkSectionLayer2, vertexSorter);
+                    built.resortTransparent(layer, vertexSorter);
                 }
-                SectionBuffers sectionBuffers = built.buffers.get(chunkSectionLayer2);
-                if (sectionBuffers != null) {
-                    if (m == -1) {
-                        m = list.size();
-                        list.add(new DynamicUniforms.ChunkSectionInfo(new Matrix4f(RenderSystem.getModelViewMatrix()), chunk.pos().getMinBlockX(), 0, chunk.pos().getMinBlockZ(), 1.0F, j, k));
-                    }
-
-                    GpuBuffer gpuBuffer;
-                    VertexFormat.IndexType indexType;
-                    if (sectionBuffers.getIndexBuffer() == null) {
-                        if (sectionBuffers.getIndexCount() > i) {
-                            i = sectionBuffers.getIndexCount();
-                        }
-
-                        gpuBuffer = null;
-                        indexType = null;
-                    } else {
-                        gpuBuffer = sectionBuffers.getIndexBuffer();
-                        indexType = sectionBuffers.getIndexType();
-                    }
-
-                    int finalM = m;
-                    enumMap.get(chunkSectionLayer2).add(new RenderPass.Draw<>(0, sectionBuffers.getVertexBuffer(), gpuBuffer, indexType, 0, sectionBuffers.getIndexCount(), (gpuBufferSlicesx, uniformUploader) -> uniformUploader.upload("ChunkSection", gpuBufferSlicesx[finalM])));
+                SectionBuffers sectionBuffers = built.buffers.get(layer);
+                if (sectionBuffers == null) {
+                    continue;
                 }
+                if (uniformIndex == -1) {
+                    uniformIndex = chunkSectionInfos.size();
+                    chunkSectionInfos.add(new DynamicUniforms.ChunkSectionInfo(
+                            new Matrix4f(RenderSystem.getModelViewMatrix()),
+                            chunk.pos().getMinBlockX(),
+                            0,
+                            chunk.pos().getMinBlockZ(),
+                            1.0F,
+                            atlasWidth,
+                            atlasHeight
+                    ));
+                }
+
+                GpuBuffer indexBuffer;
+                VertexFormat.IndexType indexType;
+                if (sectionBuffers.indexBuffer() == null) {
+                    if (sectionBuffers.indexCount() > maxIndices) {
+                        maxIndices = sectionBuffers.indexCount();
+                    }
+                    indexBuffer = null;
+                    indexType = null;
+                } else {
+                    indexBuffer = sectionBuffers.indexBuffer();
+                    indexType = sectionBuffers.indexType();
+                }
+
+                int finalUniformIndex = uniformIndex;
+                enumMap.get(layer)
+                        .computeIfAbsent(0, ignored -> new ArrayList<>())
+                        .add(new com.mojang.blaze3d.systems.RenderPass.Draw<>(
+                                0,
+                                sectionBuffers.vertexBuffer(),
+                                indexBuffer,
+                                indexType,
+                                0,
+                                sectionBuffers.indexCount(),
+                                0,
+                                (gpuBufferSlices, uniformUploader) -> uniformUploader.upload("ChunkSection", gpuBufferSlices[finalUniformIndex])
+                        ));
             }
         }
 
-        GpuBufferSlice[] gpuBufferSlices = RenderSystem.getDynamicUniforms().writeChunkSections(list.toArray(new DynamicUniforms.ChunkSectionInfo[0]));
-        return new ChunkSectionsToRender(gpuTextureView, enumMap, i, gpuBufferSlices);
+        GpuBufferSlice[] gpuBufferSlices = RenderSystem.getDynamicUniforms().writeChunkSections(
+                chunkSectionInfos.toArray(new DynamicUniforms.ChunkSectionInfo[0])
+        );
+        return new ChunkSectionsToRender(blockAtlas, enumMap, maxIndices, gpuBufferSlices);
+    }
+
+    public void renderBlocks() {
+        if (target == null) {
+            return;
+        }
+        ChunkSectionsToRender chunkSectionsToRender = prepareChunks();
+        renderChunkSectionsLayer(chunkSectionsToRender, ChunkSectionLayerGroup.OPAQUE);
+        renderChunkSectionsLayer(chunkSectionsToRender, ChunkSectionLayerGroup.TRANSLUCENT);
     }
 
     private void renderChunkSectionsLayer(ChunkSectionsToRender chunks, ChunkSectionLayerGroup group) {
         RenderSystem.AutoStorageIndexBuffer autoStorageIndexBuffer = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
-        GpuBuffer gpuBuffer = chunks.maxIndicesRequired() == 0 ? null : autoStorageIndexBuffer.getBuffer(chunks.maxIndicesRequired());
-        VertexFormat.IndexType indexType = chunks.maxIndicesRequired() == 0 ? null : autoStorageIndexBuffer.type();
-        ChunkSectionLayer[] chunkSectionLayers = group.layers();
+        GpuBuffer sharedIndexBuffer = chunks.maxIndicesRequired() == 0 ? null : autoStorageIndexBuffer.getBuffer(chunks.maxIndicesRequired());
+        VertexFormat.IndexType sharedIndexType = chunks.maxIndicesRequired() == 0 ? null : autoStorageIndexBuffer.type();
         Minecraft minecraft = Minecraft.getInstance();
+        GpuSampler blockSampler = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR);
 
-        try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "Section layers for " + group.label(), target.getColorTextureView(), OptionalInt.empty(), target.getDepthTextureView(), OptionalDouble.empty())) {
+        try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(
+                () -> "SchematicPreview " + group.label(),
+                target.getColorTextureView(),
+                OptionalInt.empty(),
+                target.getDepthTextureView(),
+                OptionalDouble.empty()
+        )) {
             RenderSystem.bindDefaultUniforms(renderPass);
-            renderPass.bindTexture("Sampler2", minecraft.gameRenderer.lightTexture().getTextureView(), RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
+            renderPass.bindTexture(
+                    "Sampler2",
+                    minecraft.gameRenderer.lightmap(),
+                    blockSampler
+            );
 
-            for(ChunkSectionLayer chunkSectionLayer : chunkSectionLayers) {
-                List<RenderPass.Draw<GpuBufferSlice[]>> list = chunks.drawsPerLayer().get(chunkSectionLayer);
-                if (!list.isEmpty()) {
-                    if (chunkSectionLayer == ChunkSectionLayer.TRANSLUCENT) {
-                        list = list.reversed();
+            for (ChunkSectionLayer layer : group.layers()) {
+                Int2ObjectOpenHashMap<List<RenderPass.Draw<GpuBufferSlice[]>>> drawGroups = chunks.drawGroupsPerLayer().get(layer);
+                if (drawGroups == null) {
+                    continue;
+                }
+                renderPass.setPipeline(layer.pipeline());
+                renderPass.bindTexture("Sampler0", chunks.textureView(), blockSampler);
+                for (List<RenderPass.Draw<GpuBufferSlice[]>> draws : drawGroups.values()) {
+                    if (draws.isEmpty()) {
+                        continue;
                     }
-
-                    renderPass.setPipeline(chunkSectionLayer.pipeline());
-                    renderPass.bindTexture("Sampler0", chunks.textureView(), RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
-                    renderPass.drawMultipleIndexed(list, gpuBuffer, indexType, List.of("ChunkSection"), chunks.chunkSectionInfos());
+                    List<RenderPass.Draw<GpuBufferSlice[]>> drawList = layer == ChunkSectionLayer.TRANSLUCENT ? draws.reversed() : draws;
+                    renderPass.drawMultipleIndexed(drawList, sharedIndexBuffer, sharedIndexType, List.of("ChunkSection"), chunks.chunkSectionInfos());
                 }
             }
         }
-    }
-
-    public void renderBlocks() {
-        ChunkSectionsToRender chunkSectionsToRender = prepareChunks();
-        renderChunkSectionsLayer(chunkSectionsToRender, ChunkSectionLayerGroup.OPAQUE);
-        renderChunkSectionsLayer(chunkSectionsToRender, ChunkSectionLayerGroup.TRANSLUCENT);
-        renderChunkSectionsLayer(chunkSectionsToRender, ChunkSectionLayerGroup.TRIPWIRE);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -305,6 +353,22 @@ public class SchematicPreviewRenderer implements AutoCloseable {
 
     private record ChunkEntry(ChunkPos pos, CompletableFuture<@Nullable BuiltChunk> future) {}
 
+    private record SectionBuffers(
+            GpuBuffer vertexBuffer,
+            GpuBuffer indexBuffer,
+            int indexCount,
+            VertexFormat.IndexType indexType
+    ) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            vertexBuffer.close();
+            if (indexBuffer != null) {
+                indexBuffer.close();
+            }
+        }
+    }
+
     private record BuiltChunk(
             Map<ChunkSectionLayer, BufferBuilder> builderCache,
             Map<ChunkSectionLayer, ByteBufferBuilder> allocatorCache,
@@ -318,12 +382,11 @@ public class SchematicPreviewRenderer implements AutoCloseable {
         }
 
         private void uploadBuffer(ChunkSectionLayer layer, VertexSorting vertexSorter) {
-            SectionBuffers buffers = this.buffers.get(layer);
-            if (buffers != null) {
+            if (buffers.containsKey(layer)) {
                 return;
             }
             BufferBuilder builder = builderCache.get(layer);
-            if (builder == null || !builder.building) {
+            if (builder == null) {
                 return;
             }
             MeshData built = builder.build();
@@ -349,35 +412,37 @@ public class SchematicPreviewRenderer implements AutoCloseable {
                     built.indexBuffer()
             )
                     : null;
-            buffers = new SectionBuffers(vertexBuffer, indexBuffer, built.drawState().indexCount(), built.drawState().indexType());
-            this.buffers.put(layer, buffers);
+            buffers.put(layer, new SectionBuffers(vertexBuffer, indexBuffer, built.drawState().indexCount(), built.drawState().indexType()));
         }
 
         private void resortTransparent(ChunkSectionLayer layer, VertexSorting vertexSorter) {
             MeshData.SortState sortState = sortStates.get(layer);
-            if (sortState != null) {
-                SectionBuffers buffers = this.buffers.get(layer);
-                if (buffers != null) {
-                    GpuBuffer indexBuffer = buffers.getIndexBuffer();
-                    if (indexBuffer != null && !indexBuffer.isClosed()) {
-                        ByteBufferBuilder allocator = getAllocatorByLayer(layer);
-                        try (ByteBufferBuilder.Result result = sortState.buildSortedIndexBuffer(allocator, vertexSorter)) {
-                            if (result != null) {
-                                RenderSystem.getDevice().createCommandEncoder()
-                                        .writeToBuffer(indexBuffer.slice(), result.byteBuffer());
-                            }
-                        }
-                    }
+            if (sortState == null) {
+                return;
+            }
+            SectionBuffers sectionBuffers = buffers.get(layer);
+            if (sectionBuffers == null || sectionBuffers.indexBuffer() == null || sectionBuffers.indexBuffer().isClosed()) {
+                return;
+            }
+            ByteBufferBuilder allocator = getAllocatorByLayer(layer);
+            try (ByteBufferBuilder.Result result = sortState.buildSortedIndexBuffer(allocator, vertexSorter)) {
+                if (result != null) {
+                    RenderSystem.getDevice().createCommandEncoder()
+                            .writeToBuffer(sectionBuffers.indexBuffer().slice(), result.byteBuffer());
                 }
             }
         }
 
         private BufferBuilder getBuilderByLayer(ChunkSectionLayer layer) {
-            return builderCache.computeIfAbsent(layer, l -> new BufferBuilder(getAllocatorByLayer(l), l.pipeline().getVertexFormatMode(), l.pipeline().getVertexFormat()));
+            return builderCache.computeIfAbsent(layer, ignored -> new BufferBuilder(
+                    getAllocatorByLayer(layer),
+                    layer.pipeline().getVertexFormatMode(),
+                    layer.pipeline().getVertexFormat()
+            ));
         }
 
         private ByteBufferBuilder getAllocatorByLayer(ChunkSectionLayer layer) {
-            return allocatorCache.computeIfAbsent(layer, l -> new ByteBufferBuilder(1536));
+            return allocatorCache.computeIfAbsent(layer, ignored -> new ByteBufferBuilder(1536));
         }
 
         @Override
@@ -386,7 +451,6 @@ public class SchematicPreviewRenderer implements AutoCloseable {
             builtBuffers.values().forEach(MeshData::close);
             buffers.values().forEach(SectionBuffers::close);
         }
-
     }
 
 }

--- a/src/main/java/ru/dimaskama/schematicpreview/render/WorldSchematicWrapper.java
+++ b/src/main/java/ru/dimaskama/schematicpreview/render/WorldSchematicWrapper.java
@@ -6,6 +6,7 @@ import fi.dy.masa.litematica.schematic.LitematicaSchematic;
 import fi.dy.masa.litematica.schematic.container.LitematicaBlockStateContainer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -33,6 +34,8 @@ import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.alchemy.PotionBrewing;
 import net.minecraft.world.item.crafting.RecipeAccess;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.clock.ClockManager;
+import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.ExplosionDamageCalculator;
@@ -74,8 +77,9 @@ import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-public class WorldSchematicWrapper extends Level implements LightChunkGetter {
+public class WorldSchematicWrapper extends Level implements LightChunkGetter, BlockAndTintGetter {
 
+    private final Minecraft mc;
     private final LevelLightEngine lightingProvider = new FakeLightingProvider(this);
     private final FakeChunkManager fakeChunkManager = new FakeChunkManager();
     private final WorldBorder worldBorder = new WorldBorder();
@@ -89,6 +93,7 @@ public class WorldSchematicWrapper extends Level implements LightChunkGetter {
     private Map<BlockPos, Supplier<BlockEntity>> blockEntities;
 
     public WorldSchematicWrapper(Minecraft mc) {
+        this.mc = mc;
         super(
                 new ClientLevel.ClientLevelData(Difficulty.PEACEFUL, false, true),
                 Level.OVERWORLD,
@@ -171,18 +176,23 @@ public class WorldSchematicWrapper extends Level implements LightChunkGetter {
     }
 
     @Override
-    public float getShade(Direction direction, boolean shaded) {
-        return 1.0F;
-    }
-
-    @Override
-    public LevelLightEngine getLightEngine() {
-        return lightingProvider;
+    public CardinalLighting cardinalLighting() {
+        return CardinalLighting.DEFAULT;
     }
 
     @Override
     public int getBlockTint(BlockPos pos, ColorResolver colorResolver) {
         return colorResolver.getColor(biome, pos.getX(), pos.getZ());
+    }
+
+    @Override
+    public ClockManager clockManager() {
+        return mc.level.clockManager();
+    }
+
+    @Override
+    public LevelLightEngine getLightEngine() {
+        return lightingProvider;
     }
 
     @Override

--- a/src/main/resources/schematicpreview.accesswidener
+++ b/src/main/resources/schematicpreview.accesswidener
@@ -1,4 +1,4 @@
-accessWidener	v2	named
+accessWidener	v2	official
 accessible	field	net/minecraft/client/renderer/MultiBufferSource$BufferSource	sharedBuffer	Lcom/mojang/blaze3d/vertex/ByteBufferBuilder;
 accessible	field	net/minecraft/client/renderer/MultiBufferSource$BufferSource	fixedBuffers	Ljava/util/SequencedMap;
 extendable  method  net/minecraft/client/renderer/MultiBufferSource$BufferSource    endBatch        (Lnet/minecraft/client/renderer/rendertype/RenderType;Lcom/mojang/blaze3d/vertex/BufferBuilder;)V

--- a/src/main/resources/schematicpreview.mixins.json
+++ b/src/main/resources/schematicpreview.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "ru.dimaskama.schematicpreview.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "MaterialListPlacementAccessor",
     "MaterialListSchematicAccessor",


### PR DESCRIPTION
## Summary

Ports SchematicPreview to **Minecraft 26.1.2** (Fabric Loader 0.19.2, Fabric API 0.150.0+26.1.2, MaLiLib 0.28.6, Litematica 0.27.6).

This work was **generated entirely with AI assistance** (Cursor) and has been **tested in-game on 26.1.2** with a real modpack. Preview rendering, textures, schematic browser thumbnails, side-panel interaction, and stability were verified working.

### Changes
- Update build toolchain for 26.1 unobfuscated mappings (Fabric Loom 1.16.x, Gradle 9.4, Java 25)
- Port GUI widgets to MaLiLib `GuiContext` / 26.1 render-state APIs
- Port schematic preview rendering to 26.1 chunk/GPU pipeline (`BlockModelRendererSchematic`, offscreen `TextureTarget`, manual render passes)
- Fix preview drawing to offscreen framebuffer instead of main render target
- Fix `ConcurrentModificationException` from parallel chunk mesh builds (per-chunk renderer instances)
- Fix preview flicker (avoid unnecessary full clears/redraws every frame)
- Fix incorrect block textures (bind block atlas on `Sampler0`)
- Update `WorldSchematicWrapper` for 26.1 `BlockAndTintGetter` API

### Version
`0.0.20+26.1.2`

## Test plan
- [x] Mod loads on Minecraft 26.1.2 with Litematica + MaLiLib
- [x] Schematic browser side preview renders correctly
- [x] List thumbnails render without flashing
- [x] Block textures appear correct (block entities e.g. chests also look correct)
- [x] Rotate / zoom / freecam / fullscreen preview work
- [x] No crash from parallel chunk mesh building when browsing schematics

Happy to adjust anything to match upstream conventions or split this into smaller PRs if preferred.